### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Job Application Letter [![Build Status](https://travis-ci.org/azu/open-job-letter.svg?branch=master)](https://travis-ci.org/azu/open-job-letter)
 
-これは求人記事（Hire Meな記事）です。
+これは求職記事（Hire Meな記事）です。
 無関係な方はスルーしてください。
 
 ## ステータス


### PR DESCRIPTION
冒頭で `求人記事` となっていましたが
他の箇所では
> スカウトでは、自身の目的と一致しないことも多いためこの"求職記事"で指針を明確にしようと思った

のように書かれていたためtypoかなと思いました(違ったらスルーしてください)